### PR TITLE
Fix template substituion and add customizable death message format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /.idea
 /out
 DiscordBridge.iml
+/bin/
+/.settings/
+/.classpath
+/.project

--- a/src/com/falyrion/discordbridge/DiscordBot.java
+++ b/src/com/falyrion/discordbridge/DiscordBot.java
@@ -43,7 +43,7 @@ public class DiscordBot extends ListenerAdapter {
     @Override
     public void onReady(ReadyEvent event) {
         System.out.println("[EasyDiscordBridge] Bot ready and logged in!");
-        DiscordBridgeMain.getInstance().sendMessageToDiscord("", "", 1);
+        DiscordBridgeMain.getInstance().sendMessageToDiscord(null, null, 1);
     }
 
     /**

--- a/src/com/falyrion/discordbridge/DiscordBridgeMain.java
+++ b/src/com/falyrion/discordbridge/DiscordBridgeMain.java
@@ -5,9 +5,11 @@ import gamelistener.GameEventListener_Death;
 import gamelistener.GameEventListener_Join;
 import gamelistener.GameEventListener_Quit;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.json.simple.JSONValue;
 
 import javax.security.auth.login.LoginException;
 import java.util.concurrent.ExecutionException;
@@ -27,6 +29,7 @@ public class DiscordBridgeMain extends JavaPlugin implements Listener {
     private String serverStopMessage;
     private String playerJoinMessage;
     private String playerQuitMessage;
+    private String playerDeathMessage;
     private String playerMessageToGame;
     private String playerMessageToDiscord;
 
@@ -107,7 +110,14 @@ public class DiscordBridgeMain extends JavaPlugin implements Listener {
                     playerQuitMessage = config.getString("playerQuitMessage");
                 }
 
-
+                if (config.getBoolean("callPlayerDeath")) {
+                    playerDeathMessage = config.getString("playerDeathMessage");
+                    if (playerDeathMessage == null) {
+                        // Probably v1.0.0.0 config, use implicit default from that version
+                        playerDeathMessage = "**%s**";
+                    }
+                }
+                
             }
 
         }
@@ -120,7 +130,7 @@ public class DiscordBridgeMain extends JavaPlugin implements Listener {
     public void onDisable() {
 
         // Send shut down message to discord
-        sendMessageToDiscord("", "", 2);
+        sendMessageToDiscord(null, null, 2);
 
         System.out.println("[EasyDiscordBridge] Plugin v1.0.0.0 disabled");
     }
@@ -132,15 +142,24 @@ public class DiscordBridgeMain extends JavaPlugin implements Listener {
      * @throws InterruptedException: InterruptedException
      */
     public void sendMessageToGame(String msg, String author) throws ExecutionException, InterruptedException {
-
-        String fullMessage = playerMessageToGame.replace("%p", author);
-        String finalFullMessage = fullMessage.replace("%s", msg);
+        String safeAuthor = sanitizeForGame(author);
+        String safeMsg = sanitizeForGame(msg);
+        String fullMessage = applyTemplate(playerMessageToGame, safeMsg, safeAuthor);
 
         Bukkit.getScheduler().callSyncMethod( this, () -> Bukkit.dispatchCommand(
                 Bukkit.getConsoleSender(),
-                "tellraw @a \"" + finalFullMessage + "\"")
+                "tellraw @a \"" + fullMessage + "\"")
         ).get();
 
+    }
+    
+    /**
+     * Sanitizes user input to ensure it is a valid JSON string and can safely be inserted into Minecraft chat.
+     * @param unsafe the raw data to be sanitized
+     * @return escaped data
+     */
+    private String sanitizeForGame(String unsafe) {
+        return JSONValue.escape(ChatColor.stripColor(unsafe));
     }
 
     /**
@@ -149,38 +168,96 @@ public class DiscordBridgeMain extends JavaPlugin implements Listener {
      * @param type: int, Message Type (0=default, 1=serverStart, 2=serverStop, 3=playerJoin, 4=playerQuit,
      *            5=playerDeath)
      */
-    public void sendMessageToDiscord(String msg, String userName, int type) {
-
-        switch (type) {
-
-            // default
-            case 0 -> {
-                String chatMsg = playerMessageToDiscord.replace("%p", userName);
-                chatMsg = chatMsg.replace("%s", msg);
-                bot.sendMessageOnChannel(writeChannelID, chatMsg);
-            }
-
-            // Server start and stop
-            case 1 -> bot.sendMessageOnChannel(writeChannelID, serverStartMessage);
-            case 2 -> bot.sendMessageOnChannel(writeChannelID, serverStopMessage);
-
-            // Player join
-            case 3 -> {
-                String joinMsg = playerJoinMessage.replace("%p", userName);
-                bot.sendMessageOnChannel(writeChannelID, joinMsg);
-            }
-
-            // Player quit
-            case 4 -> {
-                String quitMsg = playerQuitMessage.replace("%p", userName);
-                bot.sendMessageOnChannel(writeChannelID, quitMsg);
-            }
-
-            // Player death
-            case 5 -> bot.sendMessageOnChannel(writeChannelID, msg);
+    public void sendMessageToDiscord(String userMsg, String userName, int type) {
+        
+        if (userMsg != null && !userMsg.isEmpty()) {
+            userMsg = sanitizeForDiscord(userMsg);
         }
+        
+        if (userName != null && !userName.isEmpty()) {
+            userName = sanitizeForDiscord(userName);
+        }
+        
+        String discordMsg = applyTemplate(switch (type) {
+        case 0 -> playerMessageToDiscord;
+        case 1 -> serverStartMessage;
+        case 2 -> serverStopMessage;
+        case 3 -> playerJoinMessage;
+        case 4 -> playerQuitMessage;
+        case 5 -> playerDeathMessage;
+        default -> throw new IllegalArgumentException("Unexpected type: " + type);
+        }, userMsg, userName);
+        
+        bot.sendMessageOnChannel(writeChannelID, discordMsg);
+    }
+    
+    /**
+     * Sanitizes user input to ensure it is can safely be inserted into Discord chat.
+     * @param unsafe the raw data to be sanitized
+     * @return escaped data
+     */
+    private String sanitizeForDiscord(String unsafe) {
+        return ChatColor.stripColor(unsafe);
     }
 
-
+    /**
+     * Inserts given message and author information into the provided template.
+     * @param template the template to use
+     * @param safeMsg sanitized message
+     * @param safeAuthor sanitized author name, or {@code null} to ignore <tt>%p</tt>
+     * @return the constructed message
+     */
+    private String applyTemplate(String template, String safeMsg, String safeAuthor) {
+        StringBuilder result = new StringBuilder();
+        
+        for (int i = 0; i < template.length(); i++) {
+            char c = template.charAt(i);
+            
+            // Attempt to interpret the character as the beginning of the sequence
+            if (c == '%' && i != template.length() - 1) {
+                
+                // Whether the '%' and the following char should be appended themselves
+                boolean consume = true;
+                
+                switch (template.charAt(i + 1)) {
+                    
+                // %s - replace with message
+                case 's':
+                    result.append(safeMsg);
+                    break;
+                    
+                // %% - this is an escaped single '%'
+                case '%':
+                    result.append("%");
+                    break;
+                    
+                // %p - replace with author
+                case 'p':
+                    if (safeAuthor != null) {
+                        result.append(safeAuthor);
+                        break;
+                    }
+                    // else FALL THROUGH
+                    
+                // Someone placed a single % - this is not a sequence
+                // (or we FELL THROUGH from %p)
+                default:
+                    consume = false;
+                    break;
+                }
+                
+                if (consume) {
+                    // Skip '%' and the following character
+                    i += 1;
+                    continue;
+                }
+            }
+            
+            result.append(c);
+        }
+        
+        return result.toString();
+    }
+    
 }
 

--- a/src/config.yml
+++ b/src/config.yml
@@ -20,8 +20,9 @@ textChannelWrite: "0"
 # Note:
 # -> %p will be replaced with player name/ discord name. DO NOT DELETE THIS %p.
 # -> %s will be replaced with the message. DO NOT DELETE THIS %s.
-# -> For messages that go to discord, follow discords message formatting options.
-# -> For messages that go to the game, follow minecrafts message formatting options.
+# -> %% will be replaced with a single %.
+# -> For messages that go to Discord, follow Discord's message formatting options.
+# -> For messages that go to Minecraft, follow Minecraft's message formatting options.
 
 # Message format for messages from discord to the game
 playerMessageToGame: "§6§l[Discord] §6%p: §r%s"
@@ -47,4 +48,4 @@ playerQuitMessage: "**%p has left the game**"
 
 # Write in discord chat that a player died (with reason)?
 callPlayerDeath: true
-
+playerDeathMessage: "**%s**"

--- a/src/gamelistener/GameEventListener_Death.java
+++ b/src/gamelistener/GameEventListener_Death.java
@@ -14,9 +14,9 @@ public class GameEventListener_Death implements Listener {
     @EventHandler
     public void onPlayerDeath(PlayerDeathEvent event) {
 
-        String deathMessage = "**" + event.getDeathMessage() + "**";
+        String deathMessage = event.getDeathMessage();
 
-        DiscordBridgeMain.getInstance().sendMessageToDiscord(deathMessage, "", 5);
+        DiscordBridgeMain.getInstance().sendMessageToDiscord(deathMessage, null, 5);
 
     }
 

--- a/src/gamelistener/GameEventListener_Join.java
+++ b/src/gamelistener/GameEventListener_Join.java
@@ -16,7 +16,7 @@ public class GameEventListener_Join implements Listener {
 
         String playerName = event.getPlayer().getDisplayName();
 
-        DiscordBridgeMain.getInstance().sendMessageToDiscord("", playerName, 3);
+        DiscordBridgeMain.getInstance().sendMessageToDiscord(null, playerName, 3);
 
     }
 

--- a/src/gamelistener/GameEventListener_Quit.java
+++ b/src/gamelistener/GameEventListener_Quit.java
@@ -16,7 +16,7 @@ public class GameEventListener_Quit implements Listener {
 
         String playerName = event.getPlayer().getDisplayName();
 
-        DiscordBridgeMain.getInstance().sendMessageToDiscord("", playerName, 4);
+        DiscordBridgeMain.getInstance().sendMessageToDiscord(null, playerName, 4);
 
     }
 }


### PR DESCRIPTION
Looking through the code I have noticed that messages are displayed to Minecraft players by issuing a `/tellraw` command, where the message is substituted as follows:
```
"tellraw @a \" + message + \""
```
This is unsafe. Consider `Bob` writing `I said "Hi" to Alice` in Discord chat. The command would look like this:
```
tellraw @a "§6§l[Discord] §6Bob: §rI said "Hi" to Alice"
```
Notice that from `tellraw`'s JSON parser's point of view, the second argument is actually _two_ quoted strings, `§6§l[Discord] §6Bob: §rI said ` and ` to Alice`, joined by `Hi`. This is an invalid JSON object, and so the command fails for no apparent reason. The issue becomes even worse if the quotes make it into someone's Discord username (e.g. `Bob "Pwner" Brown` or some weird emoticon).

Unrelated, there is an issue with paragraph signs being completely legit characters in Discord while having special meaning in Minecraft. Typing `§` in Discord chat would result in formatted text in Minecraft. While on many servers that would be considered a feature, albeit very pointless, some server owners may wish to reserve the right to format Minecraft messages to privileged players, turning this into an exploit.

While digging trying to fix these two bugs I found a third one. This issue resides in template substitution itself. Take a look:
```
String chatMsg = playerMessageToDiscord.replace("%p", userName);
chatMsg = chatMsg.replace("%s", msg);
```
Consider `userName = "Bob %s"`. Then `chatMsg` is initially `"[Bob %s] %s"`, which results in duplicate messages: `[Bob Hello] Hello` instead of `[Bob %s] Hello`.

The first two problems are resolved by properly sanitizing user input (in this case, stripping Minecraft control codes and escaping the result with JSON). Multiple `String.replace` uses are trickier to fix, but its nothing some char juggling can't do.

None of the three problems are particularly damning, but they can cause some amount of annoyance when players eventually stumble upon them.

Oh, yeah, I also added player death message customization for those who want to change its formatting or add hilarious emojis. Finally, **I haven't done much testing**, so please do check that everything works correctly if you're planning to merge this PR.