### PR TITLE
Add /say integration, improve log usage

### DIFF
--- a/src/com/falyrion/discordbridge/DiscordBot.java
+++ b/src/com/falyrion/discordbridge/DiscordBot.java
@@ -9,7 +9,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import org.bukkit.Bukkit;
 
 import javax.security.auth.login.LoginException;
-import java.util.concurrent.ExecutionException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 
@@ -45,7 +45,7 @@ public class DiscordBot extends ListenerAdapter {
      */
     @Override
     public void onReady(ReadyEvent event) {
-        log.info("[EasyDiscordBridge] Bot ready and logged in!");
+        log.info("Bot ready and logged in!");
         DiscordBridgeMain.getInstance().sendMessageToDiscord(null, null, 1);
     }
 
@@ -56,27 +56,28 @@ public class DiscordBot extends ListenerAdapter {
     @Override
     public void onMessageReceived(MessageReceivedEvent event) {
 
-        if(event.getChannel().getId().equals(DiscordBridgeMain.getInstance().readChannelID)) {
-            if (!event.getMessage().getAuthor().isBot()) {
+        if (!event.getChannel().getId().equals(DiscordBridgeMain.getInstance().readChannelID)) {
+            return;
+        }
+        
+        if (event.getMessage().getAuthor().isBot()) {
+            return;
+        }
 
-                // Get msg contents
-                Message msg = event.getMessage();
-                String msgContentRaw = msg.getContentRaw();
+        // Get msg contents
+        Message msg = event.getMessage();
+        String msgContentRaw = msg.getContentRaw();
 
-                // Get msg author
-                String author = event.getAuthor().getName();
+        // Get msg author
+        String author = event.getAuthor().getName();
 
-                // Call method in main class to send message in game
-                try {
-                    DiscordBridgeMain.getInstance().sendMessageToGame(msgContentRaw, author);
-                } catch (ExecutionException e) {
-                    log.warning("[EasyDiscordBridge] ExecutionException. Full error log:");
-                    e.printStackTrace();
-                } catch (InterruptedException e) {
-                    log.warning("[EasyDiscordBridge] InterruptedException. Full error log:");
-                    e.printStackTrace();
-                }
-            }
+        // Call method in main class to send message in game
+        try {
+            DiscordBridgeMain.getInstance().sendMessageToGame(msgContentRaw, author);
+        } catch (Exception e) {
+            log.info("Could not handle a Discord message");
+            log.info("Author is \"" + author + "\", message is \"" + msgContentRaw + "\"");
+            log.log(Level.SEVERE, "An exception has occurred while handling a Discord message", e);
         }
     }
 

--- a/src/com/falyrion/discordbridge/DiscordBridgeMain.java
+++ b/src/com/falyrion/discordbridge/DiscordBridgeMain.java
@@ -5,6 +5,8 @@ import gamelistener.GameEventListener_Chat;
 import gamelistener.GameEventListener_Death;
 import gamelistener.GameEventListener_Join;
 import gamelistener.GameEventListener_Quit;
+import gamelistener.GameEventListener_SayCommand;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -41,15 +43,13 @@ public class DiscordBridgeMain extends JavaPlugin implements Listener {
 
     FileConfiguration config = getConfig();
 
-    private final Logger log = Bukkit.getLogger();
+    private final Logger log = getLogger();
 
     DiscordBot bot = new DiscordBot();
 
 
     @Override
     public void onEnable() {
-
-        log.info("[EasyDiscordBridge] starting plugin...");
 
         instance = this;
 
@@ -70,22 +70,19 @@ public class DiscordBridgeMain extends JavaPlugin implements Listener {
         // Bot related
 
         if (discordBotToken == null || readChannelID == null || writeChannelID == null) {
-            log.warning("[EasyDiscordBridge] Config file not available or invalid.");
+            log.warning("Config file not available or invalid.");
         } else if (discordBotToken.equals("0") || readChannelID.equals("0") || writeChannelID.equals("0")) {
-            log.warning("[EasyDiscordBridge] Bot data not set up in config file yet. Can not start bot. Please update the token and channel IDs in the config file and restart your server.");
+            log.warning("Bot data not set up in config file yet. Can not start bot. Please update the token and channel IDs in the config file and restart your server.");
         } else {
-            log.info("[EasyDiscordBridge] Loaded config:");
-            log.info("[EasyDiscordBridge] The bot will read from channel ID: " + readChannelID);
-            log.info("[EasyDiscordBridge] The bot will write to channel ID: " + writeChannelID);
+            log.info("Read channel ID: " + readChannelID + "; write channel ID: " + writeChannelID);
 
             // Create and load discord bot
             boolean botSuccessful = true;
             try {
-                log.info("[EasyDiscordBridge] Trying to start bot...");
                 bot.createBot(discordBotToken);
             } catch (LoginException e) {
                 botSuccessful = false;
-                log.info("[EasyDiscordBridge] Failed to start bot. Check if your token is correct.");
+                log.warning("Failed to start bot. Check if your token is correct.");
                 e.printStackTrace();
             }
 
@@ -94,6 +91,7 @@ public class DiscordBridgeMain extends JavaPlugin implements Listener {
 
                 // Register chat events
                 Bukkit.getServer().getPluginManager().registerEvents(new GameEventListener_Chat(), this);
+                Bukkit.getServer().getPluginManager().registerEvents(new GameEventListener_SayCommand(), this);
 
                 // Register other events if enabled in config
                 if (config.getBoolean("callPlayerJoin")) {
@@ -147,11 +145,6 @@ public class DiscordBridgeMain extends JavaPlugin implements Listener {
             getCommand("discord").setExecutor(new Cmd_DiscordLink());
         }
 
-        // -------------------------------------------------------------------------------------------------------------
-        // Log
-
-        log.info("[EasyDiscordBridge] Plugin v1.1.0.0 enabled");
-
     }
 
     @Override
@@ -161,8 +154,6 @@ public class DiscordBridgeMain extends JavaPlugin implements Listener {
         if (botLoaded) {
             sendMessageToDiscord(null, null, 2);
         }
-
-        log.info("[EasyDiscordBridge] Plugin v1.1.0.0 disabled");
     }
 
     /**
@@ -180,7 +171,8 @@ public class DiscordBridgeMain extends JavaPlugin implements Listener {
                 Bukkit.getConsoleSender(),
                 "tellraw @a \"" + fullMessage + "\"")
         ).get();
-
+        
+        log.info("<" + author + "> " + msg);
     }
 
     /**

--- a/src/commands/Cmd_DiscordLink.java
+++ b/src/commands/Cmd_DiscordLink.java
@@ -14,7 +14,6 @@ public class Cmd_DiscordLink implements CommandExecutor {
     public boolean onCommand(CommandSender commandSender, Command command, String commandLabel, String[] arguments) {
 
         if (commandSender instanceof Player) {
-            Player player = (Player) commandSender;
             TextComponent textComponentDiscordLink = new TextComponent(DiscordBridgeMain.getInstance().discordInfoMsg);
             textComponentDiscordLink.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, DiscordBridgeMain.getInstance().discordLink));
             commandSender.spigot().sendMessage(textComponentDiscordLink);

--- a/src/gamelistener/GameEventListener_SayCommand.java
+++ b/src/gamelistener/GameEventListener_SayCommand.java
@@ -1,0 +1,45 @@
+package gamelistener;
+
+import com.falyrion.discordbridge.DiscordBridgeMain;
+
+import java.util.Locale;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.server.ServerCommandEvent;
+
+
+public class GameEventListener_SayCommand implements Listener {
+
+    /**
+     * Event Listener to register commands issued by non-players. When a /say command is issued, send its message to discord
+     * @param event: ServerCommandEvent
+     */
+    @EventHandler
+    public void onServerIssuedCommand(ServerCommandEvent event) {
+
+        handleCommandIfApplicable(event.getSender().getName(), event.getCommand());
+
+    }
+    
+    /*
+     *  TODO: SAFELY handle /say when issued by a player.
+     *  If using PlayerCommandPreprocessEvent and PlayerChatEvent, some permissions check needs to be performed before broadcasting the message to Discord.
+     */
+
+    private void handleCommandIfApplicable(String sender, String commandWithArgs) {
+        
+        String prefixableCommandWithArgs = commandWithArgs.toLowerCase(Locale.ENGLISH);
+        final String expectedPrefix = "say ";
+        
+        if (!prefixableCommandWithArgs.startsWith(expectedPrefix)) {
+            return;
+        }
+        
+        String message = commandWithArgs.substring(expectedPrefix.length());
+        
+        DiscordBridgeMain.getInstance().sendMessageToDiscord(message, "[" + sender + "]", 0);
+    }
+
+}
+


### PR DESCRIPTION
I sometimes use `/say` to communicate with players when doing maintenance on the server. This currently results in an incomprehensible mess on the Discord side, with offline players being confused as to what's going on. For this reason I thought it'd be a good idea to forward `/say` communication to Discord as well. In addition, this would help server admins that don't use Discord themselves at all. I couldn't quite figure out how to safely intercept `/say` when issued by players though - the obvious route of `PlayerCommandPreprocessEvent` or anything similar might end up broadcasting the message in Discord despite the player being denied the broadcast in-game.

Another issue I have addressed in this PR (although now I think I should've used two separate PRs) is the slightly awkward logging. Most importantly, communication from Discord to Minecraft is not logged, so following conversations from console or when browsing old logs is almost impossible. Next, I switched to using `JavaPlugin.getLogger()` to obtain a logger as recommended by Bukkit. This takes care of plugin prefixes automatically. Finally, I removed some excessive log entries that were clogging up the startup logs.